### PR TITLE
Update nokogiri dependency in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    html2text (0.3.0)
-      nokogiri (~> 1.10.3)
+    html2text (0.3.1)
+      nokogiri (>= 1.12.4)
 
 GEM
   remote: https://rubygems.org/
@@ -12,9 +12,11 @@ GEM
       thor (~> 0.18)
     colorize (0.7.7)
     diff-lcs (1.3)
-    mini_portile2 (2.4.0)
-    nokogiri (1.10.3)
-      mini_portile2 (~> 2.4.0)
+    mini_portile2 (2.6.1)
+    nokogiri (1.12.4)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    racc (1.5.2)
     rake (10.4.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -45,4 +47,4 @@ DEPENDENCIES
   rspec-collection_matchers
 
 BUNDLED WITH
-   2.0.1
+   2.2.22

--- a/html2text.gemspec
+++ b/html2text.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "LICENSE.md", "README.md", "CHANGELOG.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "nokogiri", "~> 1.10.3"
+  s.add_dependency "nokogiri", ">= 1.12.4"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-collection_matchers"


### PR DESCRIPTION
Looks like nokogiri added support for M1 in 1.11 but updating to latest
sparklemotion/nokogiri#2149
https://rubygems.org/gems/nokogiri/versions